### PR TITLE
Updated for SSLyze 3.x

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,0 +1,108 @@
+package gosslyze
+
+// Constants to compare enums and strings against
+
+const (
+	CommandErrorReasonBugInSslyze             = "BUG_IN_SSLYZE"
+	CommandErrorReasonClientCertificateNeeded = "CLIENT_CERTIFICATE_NEEDED "
+	CommandErrorReasonConnectivityIssue       = "CONNECTIVITY_ISSUE "
+	CommandErrorReasonWrongUsage              = "WRONG_USAGE "
+)
+
+const (
+	Ssl2  = "SSL_2_0"
+	Ssl3  = "SSL_3_0"
+	Tls10 = "TLS_1_0"
+	Tls11 = "TLS_1_1"
+	Tls12 = "TLS_1_2"
+	Tls13 = "TLS_1_3"
+)
+
+const (
+	ClientAuthDisabled = "DISABLED"
+	ClientAuthOptional = "OPTIONAL"
+	ClientAuthRequired = "REQUIRED"
+)
+
+const (
+	ClientAuthKeyTypePem  = "PEM"
+	ClientAuthKeyTypeAsn1 = "ASN1"
+)
+
+const (
+	EphemeralKeyTypeDH     = 28
+	EphemeralKeyTypeEC     = 408
+	EphemeralKeyTypeX25519 = 1034
+	EphemeralKeyTypeX448   = 1035
+)
+
+const (
+	// RFC4492 (now deprecated)
+	EphemeralKeyCurveTypeSect163K1 = 721
+	EphemeralKeyCurveTypeSect163R1 = 722
+	EphemeralKeyCurveTypeSect163R2 = 723
+	EphemeralKeyCurveTypeSect193R1 = 724
+	EphemeralKeyCurveTypeSect193R2 = 725
+	EphemeralKeyCurveTypeSect233K1 = 726
+	EphemeralKeyCurveTypeSect233R1 = 727
+	EphemeralKeyCurveTypeSect239K1 = 728
+	EphemeralKeyCurveTypeSect283K1 = 729
+	EphemeralKeyCurveTypeSect283R1 = 730
+	EphemeralKeyCurveTypeSect409K1 = 731
+	EphemeralKeyCurveTypeSect409R1 = 732
+	EphemeralKeyCurveTypeSect571K1 = 733
+	EphemeralKeyCurveTypeSect571R1 = 734
+	EphemeralKeyCurveTypeSecp160K1 = 708
+	EphemeralKeyCurveTypeSecp160R1 = 709
+	EphemeralKeyCurveTypeSecp160R2 = 710
+	EphemeralKeyCurveTypeSecp192K1 = 711
+	EphemeralKeyCurveTypeSecp224K1 = 712
+	EphemeralKeyCurveTypeSecp224R1 = 713
+	EphemeralKeyCurveTypeSecp256K1 = 714
+
+	// RFC8422 (current)
+	EphemeralKeyCurveTypeSecp192R1  = 409
+	EphemeralKeyCurveTypePrime192V1 = 409 // Intentional duplicate of SECP192R1
+	EphemeralKeyCurveTypeSecp256R1  = 415
+	EphemeralKeyCurveTypePrime256V1 = 415 // Intentional duplicate of SECP256R1
+	EphemeralKeyCurveTypeSecp384R1  = 715
+	EphemeralKeyCurveTypeSecp521R1  = 716
+	EphemeralKeyCurveTypeX25519     = 1034
+	EphemeralKeyCurveTypeX448       = 1035
+)
+
+const (
+	TicketResumptionSuccess            = "SUCCEEDED"
+	TicketResumptionTicketNotAssigned  = "FAILED_TICKET_NOT_ASSIGNED"
+	TicketResumptionTicketIgnored      = "FAILED_TICKED_IGNORED"
+	TicketResumptionOnlyTls13Supported = "FAILED_ONLY_TLS_1_3_SUPPORTED"
+)
+
+const (
+	RobotVulnerableWeakOracle         = "VULNERABLE_WEAK_ORACLE"
+	RobotVulnerableStrongOracle       = "VULNERABLE_STRONG_ORACLE"
+	RobotNotVulnerableNoOracle        = "NOT_VULNERABLE_NO_ORACLE"
+	RobotNotVulnerableRsaNotSupported = "NOT_VULNERABLE_RSA_NOT_SUPPORTED"
+	RobotUnknownInconsistentResults   = "UNKNOWN_INCONSISTENT_RESULTS"
+)
+
+const (
+	OcspRespStatusSuccessful        = "SUCCESSFUL"
+	OcspRespStatusMalformedRequest  = "MALFORMED_REQUEST"
+	OcspRespStatusInternalError     = "INTERNAL_ERROR"
+	OcspRespStatusTryLater          = "TRY_LATER"
+	OcspRespStatusSignatureRequired = "SIG_REQUIRED"
+	OcspRespStatusUnauthorized      = "UNAUTHORIZED"
+)
+
+const (
+	OpportunisticTlsSmtp       = "SMTP"
+	OpportunisticTlsXmpp       = "XMPP"
+	OpportunisticTlsXMppServer = "XMPP_SERVER"
+	OpportunisticTlsFtp        = "FTP"
+	OpportunisticTlsPop3       = "POP3"
+	OpportunisticTlsLdap       = "LDAP"
+	OpportunisticTlsImap       = "IMAP"
+	OpportunisticTlsRdp        = "RDP"
+	OpportunisticTlsPostgres   = "POSTGRES"
+)

--- a/gosslyze.go
+++ b/gosslyze.go
@@ -10,49 +10,6 @@ import (
 	"strings"
 )
 
-/*
-func sample(){
-
-	// Initialize command depending on whether to use the Windows executable or SSLyze as a Python module
-	var command string
-	var args []string
-	if runtime.GOOS == "windows" {
-		command = "./bin/sslyze.exe" // Use Windows binary
-		args = []string{}
-	} else {
-		command = "python3.5" // Use SSLyze as a Python module
-		args = []string{"-m", "sslyze"}
-	}
-
-	// Create new scanner
-	s := NewScanner(command, args...)
-
-	// Set the target
-	s.WithTarget("localhost", 443)
-
-	// Set scanner flags
-	s.WithSslV3()
-	s.WithSslV2()
-	s.WithTlsV1()
-	s.WithTlsV1_1()
-	s.WithTlsV1_2()
-	s.WithTlsV1_3()
-	s.WithCcs()
-	s.WithHeartbleed()
-	s.WithRenegotiation()
-	s.WithResume()
-	s.WithCompression()
-	s.WithFallback()
-	s.WithRobot()
-	s.WithCertInfo() 		// Validate certificate
-	s.WithSni("localhost")  // Specify the hostname to connect to using sni.
-	s.WithEarlyData()
-
-	// Launch
-	s.Run()
-}
-*/
-
 type Scanner struct {
 	ctx    context.Context // Context
 	path   string          // Binary path
@@ -240,7 +197,25 @@ func (s *Scanner) WithCertInfo() {
 // WithCaFile sets the path to a local trust store file (with root certificates in PEM format) to verify the
 // validity of the server(s) certificate's chain(s) against.
 func (s *Scanner) WithCaFile(path string) {
-	s.args = append(s.args, fmt.Sprintf("--ca_file=%s", path))
+	s.args = append(s.args, fmt.Sprintf("--certinfo_ca_file=%s", path))
+}
+
+// WithClientCert sets the client certificate chain for authentication. The certificates must be in PEM format and must
+// be sorted starting with the subject's client certificate, followed by intermediate CA certificates if applicable.
+// Additionally the path of the client's private key file is set, as it is needed for client authentication as well.
+func (s *Scanner) WithClientCert(chainPath string, keyPath string) {
+	s.args = append(s.args, fmt.Sprintf("--chainPath=%s", chainPath))
+	s.args = append(s.args, fmt.Sprintf("--key=%s", keyPath))
+}
+
+// WithClientKeyFormat sets the format of the client's private key file. either "DER" or "PEM" (default)
+func (s *Scanner) WithClientKeyFormat(format string) {
+	s.args = append(s.args, fmt.Sprintf("--keyform=%s", format))
+}
+
+// WithClientKeyPass sets the passphrase of the client's private key.
+func (s *Scanner) WithClientKeyPass(pass string) {
+	s.args = append(s.args, fmt.Sprintf("--pass=%s", pass))
 }
 
 // WithSslV2 list the SSL 2.0 OpenSSL ciphers suites.
@@ -271,16 +246,6 @@ func (s *Scanner) WithTlsV1_2() {
 // WithTlsV1_3 list the tls 1.3 OpenSSL ciphers suites.
 func (s *Scanner) WithTlsV1_3() {
 	s.args = append(s.args, "--tlsv1_3")
-}
-
-// WithHttpGet will send a http get request for each cipher after completing the handshake and return the status code.
-func (s *Scanner) WithHttpGet() {
-	s.args = append(s.args, "--http_get")
-}
-
-// WithHideRejectedCiphers will not display the usually long list of cipher suites, that were rejected.
-func (s *Scanner) WithHideRejectedCiphers() {
-	s.args = append(s.args, "--hide_rejected_ciphers")
 }
 
 // Parse converts SSLyze json output to internal data structure

--- a/gosslyze.go
+++ b/gosslyze.go
@@ -134,6 +134,8 @@ func (s *Scanner) WithXmppTo(xmppTo string) {
 }
 
 // WithSni adds server name indication usage. Only affects tls1.0+ connections.
+// NOTE: SNI seems a bit buggy, it is neither possible to specify multiple SNI-hostnames for a single target scan nor is
+// it possible to set a SNI-hostname for one target in a multi target scan.
 func (s *Scanner) WithSni(sni string) {
 	s.args = append(s.args, fmt.Sprintf("--sni=%s", sni))
 }

--- a/gosslyze_test.go
+++ b/gosslyze_test.go
@@ -1,0 +1,50 @@
+package gosslyze
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestSample(t *testing.T) {
+
+	// Initialize command depending on whether to use the Windows executable or SSLyze as a Python module
+	var command string
+	var args []string
+	if runtime.GOOS == "windows" {
+		command = "./bin/sslyze.exe" // Use Windows binary
+		args = []string{}
+	} else {
+		command = "python3.8" // Use SSLyze as a Python module
+		args = []string{"-m", "sslyze"}
+	}
+
+	// Create new scanner
+	s := NewScanner(command, args...)
+
+	// Set the target
+	target := "localhost"
+	s.WithTarget(target, 443)
+
+	// Set scanner flags
+	s.WithSslV3()
+	s.WithSslV2()
+	s.WithTlsV1()
+	s.WithTlsV1_1()
+	s.WithTlsV1_2()
+	s.WithTlsV1_3()
+	s.WithCcs()
+	s.WithHeartbleed()
+	s.WithRenegotiation()
+	s.WithResume()
+	s.WithResumeRate()
+	s.WithHttpHeaders()
+	s.WithCompression()
+	s.WithFallback()
+	s.WithRobot()
+	s.WithCertInfo()  // Validate certificate
+	s.WithSni(target) // Specify the hostname to connect to using sni.
+	s.WithEarlyData()
+
+	// Launch
+	s.Run()
+}

--- a/model.go
+++ b/model.go
@@ -97,7 +97,7 @@ type CommandResults struct {
 		IsSupported bool `json:"supports_early_data"`
 	} `json:"tls_1_3_early_data"`
 
-	OpensslCcs *struct {
+	OpenSslCcs *struct {
 		IsVulnerable bool `json:"is_vulnerable_to_ccs_injection"`
 	} `json:"openssl_ccs_injection"`
 
@@ -247,7 +247,7 @@ type AcceptedCipher struct {
 
 type Cipher struct {
 	Name        string `json:"name"`
-	OpensslName string `json:"openssl_name"`
+	OpenSslName string `json:"openssl_name"`
 	IsAnonymous bool   `json:"is_anonymous"`
 	KeySize     int    `json:"key_size"`
 }
@@ -335,7 +335,7 @@ type ExpectedCtHeader struct {
 }
 
 // Helper struct, because SSLyze (or Cryptography to be more precise) converts the time into UTC and removes the time
-// zone information. Therefore golang can no longer parse the input automatically -.-
+// zone information. Therefore golang can no longer parse the input automatically..
 const timeFormat = "2006-01-02T15:04:05"
 
 type UtcTime struct {

--- a/model.go
+++ b/model.go
@@ -140,7 +140,7 @@ type Deployment struct {
 	PathValidation   []PathValidation `json:"path_validation_results"`
 	CertificateChain []Certificate    `json:"received_certificate_chain"`
 	HasAnchor        *bool            `json:"received_chain_contains_anchor_certificate"`
-	IsChainValid     bool             `json:"received_chain_has_valid_order"`
+	HasValidOrder    bool             `json:"received_chain_has_valid_order"`
 	SymantecDistrust *bool            `json:"verified_chain_has_legacy_symantec_anchor"`
 	HasSha1          *bool            `json:"verified_chain_has_sha1_signature"`
 }

--- a/model.go
+++ b/model.go
@@ -313,6 +313,9 @@ func (c *AcceptedCipher) UnmarshalJSON(data []byte) error {
 	if !ok {
 		return errors.New("cipher_suite field missing in AcceptedCipher")
 	}
+	if rawCipherData == nil {
+		return errors.New("cipher_suite field is nil in AcceptedCipher")
+	}
 
 	c.Cipher = Cipher{}
 	errUnmar = json.Unmarshal(*rawCipherData, &c.Cipher)
@@ -324,6 +327,9 @@ func (c *AcceptedCipher) UnmarshalJSON(data []byte) error {
 	rawKeyData, ok := rawMap["ephemeral_key"]
 	if !ok {
 		c.EphemeralKey = nil
+		return nil
+	}
+	if rawKeyData == nil {
 		return nil
 	}
 	var rawKeyInfo map[string]*json.RawMessage
@@ -360,7 +366,6 @@ func (c *AcceptedCipher) UnmarshalJSON(data []byte) error {
 		if errUnmar != nil {
 			return errUnmar
 		}
-		fmt.Println(*nist)
 		c.EphemeralKey = nist
 		return nil
 	}

--- a/model.go
+++ b/model.go
@@ -90,7 +90,7 @@ type CommandResults struct {
 	TlsV1_3 *Protocol `json:"tls_1_3_cipher_suites"`
 
 	Compression *struct {
-		CompressionName bool `json:"supports_compression"`
+		IsSupported bool `json:"supports_compression"`
 	} `json:"tls_compression"`
 
 	EarlyData *struct {
@@ -172,6 +172,7 @@ type Entity struct {
 }
 
 type Attribute struct {
+	// All OIDs: https://cryptography.io/en/latest/_modules/cryptography/x509/oid/
 	Oid       Oid     `json:"oid"`
 	RfcString string `json:"rfc4514_string"`
 	Value     string `json:"value"`


### PR DESCRIPTION
- rewrite of most of the model - no more plain interface{} fields
- pointers for all the optional fields
- constants for python enums
- removed old and added new CLI parameters
