### PR TITLE
Do not treat UserWarnings as errors

### DIFF
--- a/gosslyze.go
+++ b/gosslyze.go
@@ -96,8 +96,20 @@ func (s *Scanner) Run() (*HostResult, error) {
 
 		// Check if scan threw errors
 		if stderr.Len() > 0 {
+
+			// Print error to stdout
 			fmt.Println(stderr.String())
-			return nil, errors.New(strings.Trim(stderr.String(), ".\n"))
+
+			// Ignore UserWarning errors
+			userWarningsOnly := true
+			for _, line := range strings.Split(strings.TrimSuffix(stderr.String(), "\n"), "\n") {
+				if !strings.Contains(line, "UserWarning:") {
+					userWarningsOnly = false
+				}
+			}
+			if !userWarningsOnly {
+				return nil, errors.New(strings.Trim(stderr.String(), ".\n"))
+			}
 		}
 
 		// Parse returned data


### PR DESCRIPTION
Avoids returning the scan with an error state when minor issues like the certificate-related `Country names should be two characters, but the attribute is n characters in length` warning appear during the scan.